### PR TITLE
Fix crash when deallocating

### DIFF
--- a/Pod/Classes/CYFBeaconDistanceSmoother.m
+++ b/Pod/Classes/CYFBeaconDistanceSmoother.m
@@ -19,7 +19,6 @@ static const float kAccuracyFar = 10;
 @property (nonatomic, readonly) NSUInteger historyMinLength;
 @property (nonatomic, strong, readonly) CLBeacon *beacon;
 @property (nonatomic) NSUInteger missingCount;
-@property (nonatomic, strong, readonly) CLBeacon *missingBeacon;
 
 ///Average accuracy or -1 if the beacon is missing
 @property (nonatomic) double averageAccuracy;
@@ -36,7 +35,6 @@ static const float kAccuracyFar = 10;
         _history = [NSMutableArray arrayWithCapacity:maxLength];
         _historyMaxLength = maxLength;
         _beacon = beacon;
-        _missingBeacon = [[CLBeacon alloc] init];
         _historyMinLength = minLength;
         
     }
@@ -53,7 +51,7 @@ static const float kAccuracyFar = 10;
 }
 
 - (void)addBeaconMissingRecord {
-    [self.history insertObject:self.missingBeacon atIndex:0];
+    [self.history insertObject:[NSNull null] atIndex:0];
 }
 
 
@@ -74,7 +72,7 @@ static const float kAccuracyFar = 10;
     for (NSUInteger i = 0; i < self.history.count; i++) {
         CLBeacon *record = self.history[i];
         
-        if (record == self.missingBeacon) {
+        if ([record isEqual:[NSNull null]]) {
             accuracyMissingCount++;
         }
         else if (record.accuracy < 0) {


### PR DESCRIPTION
Previously CYFBeaconHistory would create a bare bones CLBeacon object to use when indicating a missing beacon in collections. This recently created a crash because `[[CLBeacon alloc] init]` was a private `init` method that should not have been used. The effect was that anytime a CYFBeaconHistory object was deallocated from memory an exception would be thrown (http://stackoverflow.com/questions/41490685/exc-bad-access-when-setting-a-clbeacon-to-nil).

Adding `[NSNull null]` to the collections instead of the `missingBeacon` `CLBeacon` object fixes this problem without using any private initializers.